### PR TITLE
Add session info page with API integration and menu link

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "vue-router": "^4.0.12"
   },
   "devDependencies": {
-
     "@eslint/js": "^9.14.0",
     "eslint": "^9.14.0",
     "eslint-plugin-vue": "^9.30.0",
@@ -38,7 +37,6 @@
     "concurrently": "^9.2.0",
     "@vue/eslint-config-prettier": "^10.1.0",
     "prettier": "^3.3.3",
-
     "@types/node": "^20.5.9",
     "@intlify/unplugin-vue-i18n": "^4.0.0",
     "@quasar/app-vite": "^2.1.0",
@@ -52,5 +50,6 @@
     "node": "^28 || ^26 || ^24 || ^22 || ^20 || ^18",
     "npm": ">= 6.13.4",
     "yarn": ">= 1.21.1"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/boot/axios.ts
+++ b/src/boot/axios.ts
@@ -14,7 +14,7 @@ declare module 'vue' {
 // good idea to move this instance creation inside of the
 // "export default () => {}" function below (which runs individually
 // for each client)
-const api = axios.create({ baseURL: 'https://api.example.com' });
+const api = axios.create({ baseURL: '' });
 
 export default defineBoot(({ app }) => {
   // for use inside Vue files (Options API) through this.$axios and this.$api

--- a/src/components/EssentialLink.vue
+++ b/src/components/EssentialLink.vue
@@ -1,9 +1,10 @@
 <template>
   <q-item
     clickable
-    tag="a"
-    target="_blank"
-    :href="link"
+    :tag="isExternalLink ? 'a' : 'div'"
+    :target="isExternalLink ? '_blank' : undefined"
+    :href="isExternalLink ? link : undefined"
+    :to="isExternalLink ? undefined : link"
   >
     <q-item-section
       v-if="icon"

--- a/src/components/EssentialLink.vue
+++ b/src/components/EssentialLink.vue
@@ -21,6 +21,8 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue';
+
 export interface EssentialLinkProps {
   title: string;
   caption?: string;
@@ -28,9 +30,13 @@ export interface EssentialLinkProps {
   icon?: string;
 };
 
-withDefaults(defineProps<EssentialLinkProps>(), {
+const props = withDefaults(defineProps<EssentialLinkProps>(), {
   caption: '',
   link: '#',
   icon: '',
+});
+
+const isExternalLink = computed(() => {
+  return props.link?.startsWith('http') || props.link === '#';
 });
 </script>

--- a/src/components/EssentialLink.vue
+++ b/src/components/EssentialLink.vue
@@ -6,10 +6,7 @@
     :href="isExternalLink ? link : undefined"
     :to="isExternalLink ? undefined : link"
   >
-    <q-item-section
-      v-if="icon"
-      avatar
-    >
+    <q-item-section v-if="icon" avatar>
       <q-icon :name="icon" />
     </q-item-section>
 
@@ -28,7 +25,7 @@ export interface EssentialLinkProps {
   caption?: string;
   link?: string;
   icon?: string;
-};
+}
 
 const props = withDefaults(defineProps<EssentialLinkProps>(), {
   caption: '',

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -2,40 +2,19 @@
   <q-layout view="lHh Lpr lFf">
     <q-header elevated>
       <q-toolbar>
-        <q-btn
-          flat
-          dense
-          round
-          icon="menu"
-          aria-label="Menu"
-          @click="toggleLeftDrawer"
-        />
+        <q-btn flat dense round icon="menu" aria-label="Menu" @click="toggleLeftDrawer" />
 
-        <q-toolbar-title>
-          Quasar App
-        </q-toolbar-title>
+        <q-toolbar-title> Quasar App </q-toolbar-title>
 
         <div>Quasar v{{ $q.version }}</div>
       </q-toolbar>
     </q-header>
 
-    <q-drawer
-      v-model="leftDrawerOpen"
-      show-if-above
-      bordered
-    >
+    <q-drawer v-model="leftDrawerOpen" show-if-above bordered>
       <q-list>
-        <q-item-label
-          header
-        >
-          Essential Links
-        </q-item-label>
+        <q-item-label header> Essential Links </q-item-label>
 
-        <EssentialLink
-          v-for="link in linksList"
-          :key="link.title"
-          v-bind="link"
-        />
+        <EssentialLink v-for="link in linksList" :key="link.title" v-bind="link" />
       </q-list>
     </q-drawer>
 
@@ -54,55 +33,55 @@ const linksList: EssentialLinkProps[] = [
     title: 'Session Info',
     caption: 'View session details',
     icon: 'account_circle',
-    link: '/session'
+    link: '/session',
   },
   {
     title: 'Docs',
     caption: 'quasar.dev',
     icon: 'school',
-    link: 'https://quasar.dev'
+    link: 'https://quasar.dev',
   },
   {
     title: 'Github',
     caption: 'github.com/quasarframework',
     icon: 'code',
-    link: 'https://github.com/quasarframework'
+    link: 'https://github.com/quasarframework',
   },
   {
     title: 'Discord Chat Channel',
     caption: 'chat.quasar.dev',
     icon: 'chat',
-    link: 'https://chat.quasar.dev'
+    link: 'https://chat.quasar.dev',
   },
   {
     title: 'Forum',
     caption: 'forum.quasar.dev',
     icon: 'record_voice_over',
-    link: 'https://forum.quasar.dev'
+    link: 'https://forum.quasar.dev',
   },
   {
     title: 'Twitter',
     caption: '@quasarframework',
     icon: 'rss_feed',
-    link: 'https://twitter.quasar.dev'
+    link: 'https://twitter.quasar.dev',
   },
   {
     title: 'Facebook',
     caption: '@QuasarFramework',
     icon: 'public',
-    link: 'https://facebook.quasar.dev'
+    link: 'https://facebook.quasar.dev',
   },
   {
     title: 'Quasar Awesome',
     caption: 'Community Quasar projects',
     icon: 'favorite',
-    link: 'https://awesome.quasar.dev'
-  }
+    link: 'https://awesome.quasar.dev',
+  },
 ];
 
 const leftDrawerOpen = ref(false);
 
-function toggleLeftDrawer () {
+function toggleLeftDrawer() {
   leftDrawerOpen.value = !leftDrawerOpen.value;
 }
 </script>

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -51,6 +51,12 @@ import EssentialLink, { type EssentialLinkProps } from 'components/EssentialLink
 
 const linksList: EssentialLinkProps[] = [
   {
+    title: 'Session Info',
+    caption: 'View session details',
+    icon: 'account_circle',
+    link: '/session'
+  },
+  {
     title: 'Docs',
     caption: 'quasar.dev',
     icon: 'school',

--- a/src/pages/SessionPage.vue
+++ b/src/pages/SessionPage.vue
@@ -1,0 +1,172 @@
+<template>
+  <q-page class="session-page">
+    <div class="page-container">
+      <h2 class="page-title">Session Information</h2>
+      
+      <div class="controls">
+        <q-btn 
+          color="primary" 
+          @click="fetchSessionInfo"
+          :loading="loading"
+          label="Fetch Session Info"
+          class="fetch-button"
+        />
+        <q-btn 
+          v-if="error" 
+          color="secondary" 
+          @click="retry"
+          :loading="loading"
+          label="Retry"
+          class="retry-button"
+        />
+      </div>
+
+      <div v-if="error" class="error-container">
+        <q-banner class="error-banner" inline-actions rounded>
+          <template v-slot:avatar>
+            <q-icon name="error" color="negative" />
+          </template>
+          <strong>Error:</strong> {{ error }}
+          <template v-slot:action>
+            <q-btn flat color="negative" label="Retry" @click="retry" />
+          </template>
+        </q-banner>
+      </div>
+
+      <div v-if="sessionData" class="data-container">
+        <q-card class="session-card">
+          <q-card-section>
+            <div class="card-title">Session Data</div>
+          </q-card-section>
+          <q-card-section>
+            <pre class="json-display">{{ formattedSessionData }}</pre>
+          </q-card-section>
+        </q-card>
+      </div>
+
+      <div v-if="loading" class="loading-container">
+        <q-spinner-dots size="50px" color="primary" />
+        <p class="loading-text">Loading session information...</p>
+      </div>
+    </div>
+  </q-page>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import { api } from 'boot/axios';
+
+const sessionData = ref<any>(null);
+const loading = ref(false);
+const error = ref<string | null>(null);
+
+const formattedSessionData = computed(() => {
+  return sessionData.value ? JSON.stringify(sessionData.value, null, 2) : '';
+});
+
+const fetchSessionInfo = async () => {
+  loading.value = true;
+  error.value = null;
+  sessionData.value = null;
+
+  try {
+    const response = await api.get('/api/session/info');
+    sessionData.value = response.data;
+  } catch (err: any) {
+    if (err.response) {
+      error.value = `HTTP ${err.response.status}: ${err.response.data?.message || err.response.statusText}`;
+    } else if (err.request) {
+      error.value = 'Network error: Unable to reach the server';
+    } else {
+      error.value = `Request error: ${err.message}`;
+    }
+  } finally {
+    loading.value = false;
+  }
+};
+
+const retry = () => {
+  fetchSessionInfo();
+};
+
+onMounted(() => {
+  fetchSessionInfo();
+});
+</script>
+
+<style scoped>
+.session-page {
+  padding: 20px;
+}
+
+.page-container {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.page-title {
+  color: var(--q-primary);
+  margin-bottom: 20px;
+  text-align: center;
+}
+
+.controls {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 20px;
+  justify-content: center;
+}
+
+.fetch-button,
+.retry-button {
+  min-width: 150px;
+}
+
+.error-container {
+  margin-bottom: 20px;
+}
+
+.error-banner {
+  background-color: rgba(244, 67, 54, 0.1);
+  border: 1px solid #f44336;
+}
+
+.data-container {
+  margin-bottom: 20px;
+}
+
+.session-card {
+  background-color: var(--q-surface);
+  border-radius: 8px;
+}
+
+.card-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--q-primary);
+}
+
+.json-display {
+  background-color: #f5f5f5;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 15px;
+  font-family: 'Courier New', monospace;
+  font-size: 14px;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  color: #333;
+}
+
+.loading-container {
+  text-align: center;
+  padding: 40px;
+}
+
+.loading-text {
+  margin-top: 15px;
+  color: var(--q-primary);
+  font-size: 16px;
+}
+</style>

--- a/src/pages/SessionPage.vue
+++ b/src/pages/SessionPage.vue
@@ -2,18 +2,18 @@
   <q-page class="session-page">
     <div class="page-container">
       <h2 class="page-title">Session Information</h2>
-      
+
       <div class="controls">
-        <q-btn 
-          color="primary" 
+        <q-btn
+          color="primary"
           @click="fetchSessionInfo"
           :loading="loading"
           label="Fetch Session Info"
           class="fetch-button"
         />
-        <q-btn 
-          v-if="error" 
-          color="secondary" 
+        <q-btn
+          v-if="error"
+          color="secondary"
           @click="retry"
           :loading="loading"
           label="Retry"
@@ -78,7 +78,9 @@ const fetchSessionInfo = async () => {
     sessionData.value = response.data;
   } catch (err: unknown) {
     if (err && typeof err === 'object' && 'response' in err) {
-      const axiosError = err as { response: { status: number; data?: { message?: string }; statusText: string } };
+      const axiosError = err as {
+        response: { status: number; data?: { message?: string }; statusText: string };
+      };
       error.value = `HTTP ${axiosError.response.status}: ${axiosError.response.data?.message || axiosError.response.statusText}`;
     } else if (err && typeof err === 'object' && 'request' in err) {
       error.value = 'Network error: Unable to reach the server';

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -6,7 +6,7 @@ const routes: RouteRecordRaw[] = [
     component: () => import('layouts/MainLayout.vue'),
     children: [
       { path: '', component: () => import('pages/IndexPage.vue') },
-      { path: '/session', component: () => import('pages/SessionPage.vue') }
+      { path: '/session', component: () => import('pages/SessionPage.vue') },
     ],
   },
 

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -4,7 +4,10 @@ const routes: RouteRecordRaw[] = [
   {
     path: '/',
     component: () => import('layouts/MainLayout.vue'),
-    children: [{ path: '', component: () => import('pages/IndexPage.vue') }],
+    children: [
+      { path: '', component: () => import('pages/IndexPage.vue') },
+      { path: '/session', component: () => import('pages/SessionPage.vue') }
+    ],
   },
 
   // Always leave this as last one,


### PR DESCRIPTION
## Purpose

The user requested a new session information page that displays JSON data from an API endpoint. The page needed to be accessible via `/session` URL, include error handling with retry functionality, and be added to the navigation menu. Additionally, ESLint formatting issues were fixed and the API configuration was updated to use the same host as the application instead of a hardcoded external URL.

## Code changes

- **Created new SessionPage.vue**: Added a complete session info page with API integration, error handling, retry button, and loading states
- **Updated routing**: Added `/session` route to display the new SessionPage component
- **Enhanced EssentialLink component**: Modified to support both internal routes and external links with proper Vue Router integration
- **Updated navigation menu**: Added "Session Info" link at the top of the Essential Links menu
- **Fixed API configuration**: Changed axios baseURL from `api.example.com` to empty string to use same host as application
- **Code formatting**: Fixed ESLint errors including trailing commas, spacing, and added packageManager field to package.json

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d7a17006fa6f4e05befa211ce7186f83/zenith-haven)

👀 [Preview Link](https://d7a17006fa6f4e05befa211ce7186f83-zenith-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d7a17006fa6f4e05befa211ce7186f83</projectId>-->
<!--<branchName>zenith-haven</branchName>-->